### PR TITLE
feat: add community chat role

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,11 @@ export default {
       description:
         'You can assign this role to yourself to subscribe to get open-source reminders and if you like contributing to open-source software',
     },
+    COMMUNITY_CHAT: {
+      name: 'community chat',
+      description:
+        'You can assign this role to yourself to be pinged when we open a voice chat for an impromptu community session.',
+    },
   },
   COLORS: {
     message: '#0099ff',
@@ -122,6 +127,7 @@ export const selfAssignableRoles = [
   'angular',
   'c/++',
   'c#',
+  'community chat',
   'fullstack',
   'flutter',
   'go',


### PR DESCRIPTION
Adds a self-assignable community chat role.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Screenshots:

![image](https://user-images.githubusercontent.com/63889819/106474260-95060a00-6459-11eb-93e0-5c5c9be55258.png)
