### PR TITLE
feat: among us role

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,11 @@ export default {
       description:
         'You can assign this role to yourself to be pinged when we open a voice chat for an impromptu community session.',
     },
+    AMONG_US: {
+      name: 'among us',
+      description:
+        'You can assign this role to yourself to be pinged when nhcarrigan (or another Admin) runs an Among Us session.',
+    },
   },
   COLORS: {
     message: '#0099ff',
@@ -124,6 +129,7 @@ export enum UserSubscriptions {
 }
 
 export const selfAssignableRoles = [
+  'among us',
   'angular',
   'c/++',
   'c#',


### PR DESCRIPTION
Adds an among us role that functions similar to the community chat role.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>