### PR TITLE
fix(alex): allow hosts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,7 @@ export default {
       'moan',
       'latino',
       'postman-postwoman',
+      'hostesses-hosts',
     ],
   },
 };


### PR DESCRIPTION
`retext` maintains a separate rule for `host` vs `hosts`. This adds `hosts` to the allow-list.

Ref: https://discord.com/channels/699608417039286293/699609729353384036/806302465552547920

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>