### PR TITLE
feat: assignable battlesnake role

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,11 @@ export default {
       description:
         'You can assign this role to yourself to be pinged when nhcarrigan (or another Admin) runs an Among Us session.',
     },
+    BATTLESNAKE: {
+      name: 'battlesnake',
+      description:
+        "You can assign this role to yourself to be pinged when there are updates regarding community battlesnake games or Eddie' video for battlesnake",
+    },
   },
   COLORS: {
     message: '#0099ff',
@@ -148,6 +153,7 @@ export const selfAssignableRoles = [
   'ops',
   'php',
   'python',
+  'battlesnake',
   'react',
   'ruby',
   'svelte',


### PR DESCRIPTION
This adds the battlesnake role to the self-assignable role list of the bot. : )

closes #444 

## Screenshots-
![Screenshot 2021-02-17 at 9 00 37 AM](https://user-images.githubusercontent.com/62864373/108180407-bd198c80-712c-11eb-8ddf-2184adf5b441.png)
