### PR TITLE
fix: added ? to special character strip regex

### DIFF
--- a/src/words.ts
+++ b/src/words.ts
@@ -43,7 +43,7 @@ export const words = async (message: Message) => {
 // Utility function for removing special characters
 function stripSpecialCharacters(str: string) {
   // match special symbols and replace with ' '
-  str = str.replace(/[.,/#!$%&*;:{}=\-_'"~()]/g, ' ');
+  str = str.replace(/[.,/#!$%?&*;:{}=\-_'"~()]/g, ' ');
   // match double whitespace with single space for cleaner string
   return str.replace(/\s{2,}/g, ' ');
 }


### PR DESCRIPTION
## Description:
This PR adds `?` to the `words.ts` regex to `stripSpecialCharacters` before sending them through Alex.js

## Screenshots:
| Before | After |
| --- | --- |
| ![he he? gets flagged](https://user-images.githubusercontent.com/43912470/108365179-ea456800-721c-11eb-8575-9e7c61c9d49e.png) | ![he he not flagged](https://user-images.githubusercontent.com/62864373/108430840-01f60e00-7268-11eb-81bf-262920564639.png) |

closes #447 