### PR TITLE
fix(words): matching special unicode qoutes #460

### DIFF
--- a/src/words.ts
+++ b/src/words.ts
@@ -43,7 +43,7 @@ export const words = async (message: Message) => {
 // Utility function for removing special characters
 function stripSpecialCharacters(str: string) {
   // match special symbols and replace with ' '
-  str = str.replace(/[.,/#!$%?&*;:{}=\-_'"~()]/g, ' ');
+  str = str.replace(/[.,/#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
   // match double whitespace with single space for cleaner string
   return str.replace(/\s{2,}/g, ' ');
 }


### PR DESCRIPTION
closes #460 

This PR adds Left quote `“` and right quote `”` to the special characters regex. Removing the ability to escape warnings from the bot.

![Screenshot_20210304_090257](https://user-images.githubusercontent.com/17693494/109983836-d263ee80-7cc8-11eb-9c6a-5fb28ef72344.png)
