### PR TITLE
Added .gitignore for IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 .env
 # Remove firestore debug log.
 firestore-debug.log
+# Ignore IDEs (some)
+.idea/


### PR DESCRIPTION
Fixes #469 

Added `.idea/` to the `.gitignore` file.

*Why are we not using a template?*