### PR TITLE
Corrected role assignment embed

### DIFF
--- a/src/commandHandlers/roles.ts
+++ b/src/commandHandlers/roles.ts
@@ -19,7 +19,7 @@ export const command = async (arg: [string, string], embed: MessageEmbed) => {
         .setDescription(`Here is the list of all the roles on this server. You can assign almost any role to yourself. Some of the roles are admin only or given to you via a condition!\n
         ${rolesList.toString()}
         ${describedRoles.toString()}\n
-        Assigning this role to yourself:
+        Assigning a role to yourself:
         \`^iam add javascript\``);
     } else {
       // Search the roles list for the argument, and
@@ -36,10 +36,18 @@ export const command = async (arg: [string, string], embed: MessageEmbed) => {
           .addField('Usage', usage);
         console.log("ERROR- The queried role can't be found");
       } else {
-        embed.setTitle(`${specificRole} Role`)
-          .setDescription(`${rolesList.concat(describedRoles).toString()}
+        // Check if the role is self Assignable
+        const isAssignable = selfAssignableRoles.includes(specificRole);
+        if (isAssignable) {
+          embed.setTitle(`${specificRole} Role`)
+            .setDescription(`${rolesList.concat(describedRoles).toString()}
           \nAssigning this role to yourself:
           \`^iam add ${specificRole}\``);
+        } else {
+          embed
+            .setTitle(`${specificRole} Role`)
+            .setDescription(rolesList.concat(describedRoles).toString());
+        }
       }
     }
   } else {
@@ -52,7 +60,7 @@ export const command = async (arg: [string, string], embed: MessageEmbed) => {
       ${roleInfo[0].toString()}
       ${roleInfo[1].toString()}\n
       Assigning roles to yourself:
-      \`^iam add javascript\``);
+      \`^iam add javascript, go\``);
   }
   return embed;
 };


### PR DESCRIPTION
closes #446

## Description
This PR fixes the `^roles` embed, which used to give assignment suggestion for non-assignable roles.
That might have been misleading to people.

## What's the fix used?
A check to see if the role is in selfAssignableRoles.
(Could their be better ways of doing this rather than using `.includes()`?)

## Screenshots
**Before-** 
![before image assignment error](https://user-images.githubusercontent.com/74637789/108185686-95c5be00-7132-11eb-89fe-66513f55a242.png)
**After-**
![after adjustments](https://user-images.githubusercontent.com/62864373/111862838-e3c22180-897d-11eb-8bf7-eea3130f5473.png)