### PR TITLE
ref: :hammer_and_wrench: : License section updated in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "author": "",
   "private": true,
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
## Fixes Issue
#496 

## Discription
Changed the license type from `UNLICENSED` to `MIT` 

```diff
- "license": "UNLICENSED",
+ "license": "MIT",
```