### PR TITLE
fix: delete notificaiton message

### DIFF
--- a/src/alexjs/alex.handler.ts
+++ b/src/alexjs/alex.handler.ts
@@ -95,7 +95,7 @@ export class AlexHandler {
   }
 
   @On({ event: 'messageDelete' })
-  onMessageDelete(deletedMessage: Message) {
+  async onMessageDelete(deletedMessage: Message) {
     const deletedNotification = this.savedNotifications.find(
       (message: Notifications) =>
         message.messageId === deletedMessage.id &&
@@ -107,7 +107,16 @@ export class AlexHandler {
           notification.channelId !== deletedNotification.channelId &&
           notification.messageId !== deletedNotification.messageId,
       );
+
+      const notificationMessage = await deletedMessage.channel.messages.fetch(
+        deletedNotification.messageId,
+      );
+
+      if (notificationMessage && notificationMessage.deletable) {
+        await notificationMessage.delete();
+      }
     }
+
     return;
   }
 }


### PR DESCRIPTION
We have existing logic to delete the notification data from our
"database", but not the actual Discord message. This commit adds
logic to delete the actual Discord message.