### PR TITLE
Added "Kushi" to the allowed list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export default {
       'hostesses-hosts',
       'husband-wife',
       'just',
+      'kushi',
       'latino',
       'long-time-no-see',
       'master',


### PR DESCRIPTION
Fixes issue #570
The bot used to prompt Kushi as a profane word but in this fix, Kushi is added to the allowed list.