### PR TITLE
Fix Regex to show errors for backticks and `/`

### DIFF
--- a/src/alexjs/alex.handler.ts
+++ b/src/alexjs/alex.handler.ts
@@ -67,7 +67,11 @@ export class AlexHandler {
         targetNotification.notificationId,
       );
       if (notificationMessage && notificationMessage.deletable) {
-        await notificationMessage.delete().catch(console.error);
+          try {
+            await notificationMessage.delete()
+          } catch (error) {
+           console.error(error) 
+          }
 
         this.savedNotifications = this.savedNotifications.filter(
           (el) =>
@@ -113,7 +117,11 @@ export class AlexHandler {
       );
 
       if (notificationMessage && notificationMessage.deletable) {
-        await notificationMessage.delete().catch(console.error);
+        try {
+          await notificationMessage.delete()
+        } catch (error) {
+         console.error(error) 
+        }
       }
     }
 

--- a/src/alexjs/alex.handler.ts
+++ b/src/alexjs/alex.handler.ts
@@ -67,11 +67,11 @@ export class AlexHandler {
         targetNotification.notificationId,
       );
       if (notificationMessage && notificationMessage.deletable) {
-          try {
-            await notificationMessage.delete()
-          } catch (error) {
-           console.error(error) 
-          }
+        try {
+          await notificationMessage.delete();
+        } catch (error) {
+          console.error(error);
+        }
 
         this.savedNotifications = this.savedNotifications.filter(
           (el) =>
@@ -118,9 +118,9 @@ export class AlexHandler {
 
       if (notificationMessage && notificationMessage.deletable) {
         try {
-          await notificationMessage.delete()
+          await notificationMessage.delete();
         } catch (error) {
-         console.error(error) 
+          console.error(error);
         }
       }
     }

--- a/src/alexjs/alex.handler.ts
+++ b/src/alexjs/alex.handler.ts
@@ -67,7 +67,7 @@ export class AlexHandler {
         targetNotification.notificationId,
       );
       if (notificationMessage && notificationMessage.deletable) {
-        await notificationMessage.delete();
+        await notificationMessage.delete().catch(console.error);
 
         this.savedNotifications = this.savedNotifications.filter(
           (el) =>
@@ -113,7 +113,7 @@ export class AlexHandler {
       );
 
       if (notificationMessage && notificationMessage.deletable) {
-        await notificationMessage.delete();
+        await notificationMessage.delete().catch(console.error);
       }
     }
 

--- a/src/alexjs/alex.service.ts
+++ b/src/alexjs/alex.service.ts
@@ -9,7 +9,7 @@ const { defaultEmbed, alexWhitelist, preventWords } = config;
 export class AlexService {
   private stripSpecialCharacters(str: string) {
     // alexMatch special symbols and replace with ' '
-    str = str.replace(/[.,/#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
+    str = str.replace(/[.,/`#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
     // alexMatch double whitespace with single space for cleaner string
     return str.replace(/\s{2,}/g, ' ');
   }

--- a/src/alexjs/alex.service.ts
+++ b/src/alexjs/alex.service.ts
@@ -9,7 +9,7 @@ const { defaultEmbed, alexWhitelist, preventWords } = config;
 export class AlexService {
   private stripSpecialCharacters(str: string) {
     // alexMatch special symbols and replace with ' '
-    str = str.replace(/[.,/`#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
+    str = str.replace(/[.,/\\`#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
     // alexMatch double whitespace with single space for cleaner string
     return str.replace(/\s{2,}/g, ' ');
   }


### PR DESCRIPTION
Following fixes made:
   - Block code blocks (fix #602)
   - Block words escaped using `\`
   - Fix some upcoming errors (unhandled catch errors)