### PR TITLE
fix: Update the copyright holder name to `EddieHub`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Eddie Jaoude
+Copyright (c) 2020-2021 EddieHub
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Things added/changed:

- Update the copyright holder's name to `EddieHub`.
  - I believe this should be changed, as the bot is built the community and not Eddie itself. 🙂
