### PR TITLE
fix: added 'kid' to banned words

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export default {
     'madam',
     'maam',
     "ma'am",
+    "kid",
   ],
   alexWhitelist: {
     profanitySureness: 1,


### PR DESCRIPTION
fixed #622 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieBot/pull/623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

