### PR TITLE
feat: granula AlexJS ignore (#627)

### DIFF
--- a/src/alexjs/alex.service.ts
+++ b/src/alexjs/alex.service.ts
@@ -23,7 +23,10 @@ export class AlexService {
       .messages;
 
     const notifications: MessageEmbed[] = [];
-    if (alexMatch.length) {
+    if (
+      alexMatch.length &&
+      !config.allowedWords.includes(alexMatch[0].actual as string)
+    ) {
       const embed = defaultEmbed(config.colors.alerts)
         .setTitle(`You used the word "${alexMatch[0].actual}"`)
         .setDescription(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { MessageEmbed } from 'discord.js';
 
 export default {
+  // words we block in addition to AlexJS
   preventWords: [
     'guyz',
     'guyzz',
@@ -15,9 +16,12 @@ export default {
     'maam',
     "ma'am",
   ],
+  // words we allow even if AlexJS blocks (words are sometimes grouped by we want to be more granular)
+  allowedWords: ['fellow'],
   alexWhitelist: {
     profanitySureness: 1,
     noBinary: true,
+    // AlexJS to ignore these grouped words https://github.com/retextjs/retext-equality/blob/main/rules.md
     allow: [
       'add',
       'basically',


### PR DESCRIPTION
closes #627 

From the AlexJS docs the word `fellow` is grouped as part of `gal-guy` 

> woman (female), gal (female), lady (female), babe (female), bimbo (female), chick (female), guy (male), lad (male), fellow (male), dude (male), bro (male), gentleman (male)

https://github.com/retextjs/retext-equality/blob/main/rules.md

We need to write a wrapping around AlexJS to be more granular, as we want to block most of these words but want to allow some.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieBot/pull/628"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

