### PR TITLE
chad blocked word

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export default {
     'maam',
     "ma'am",
     'yessir',
+    'chad',
   ],
   alexWhitelist: {
     profanitySureness: 1,


### PR DESCRIPTION
Things added/changed:

- Add `chad` to the list of blocked words.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieBot/pull/632"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

