### PR TITLE
fix : added 'god' to whitelist

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export default {
       'superman-superwoman',
       'simple',
       'just',
+      'god'
     ],
   },
 


### PR DESCRIPTION
This is a PR relating to this issue : [BUG]: The bot bans words like god #650. Not sure if the word is profane or not, please merge after consideration maintainers!