### PR TITLE
Add "boys" to block list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export default {
   preventWords: [
     'guyz',
     'guyzz',
+    'boys',
     'bruh',
     'duude',
     'women',


### PR DESCRIPTION
I have added `boys` to the blocklist/ prevent words recommended by @eddiejaoude 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieBot/pull/658"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

