### PR TITLE
fix: allow codeblocks

### DIFF
--- a/src/alexjs/alex.service.ts
+++ b/src/alexjs/alex.service.ts
@@ -9,7 +9,7 @@ const { defaultEmbed, alexWhitelist, preventWords } = config;
 export class AlexService {
   private stripSpecialCharacters(str: string) {
     // alexMatch special symbols and replace with ' '
-    str = str.replace(/[.,/\\`#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
+    str = str.replace(/[.,/\\#!$%?&*;:{}=\-_'"“”~()]/g, ' ');
     // alexMatch double whitespace with single space for cleaner string
     return str.replace(/\s{2,}/g, ' ');
   }


### PR DESCRIPTION
In code blocks, it is usually to explain people

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieBot/pull/683"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

