### PR TITLE
CVE-2020-7753

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4911,7 +4911,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
+        "trim": "0.0.3",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",


### PR DESCRIPTION
All versions of package trim lower than 0.0.3 are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().

on trim in [package-lock.json](https://github.com/EddieHubCommunity/EddieBot/blob/-/package-lock.json).

upgrade trim to version 0.0.3 or later. For example:

```json
"dependencies": {
  "trim": ">=0.0.3"
}
```
```json
"devDependencies": {
  "trim": ">=0.0.3"
}
```

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EddieBot/pull/743"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

