### PR TITLE
fix: handle http protocol capitalization when checking links

### DIFF
--- a/src/links/checkLinks.ts
+++ b/src/links/checkLinks.ts
@@ -4,7 +4,8 @@ import type { ExtendedClient } from '../interfaces/ExtendedClient.js';
 import { errorHandler } from '../utils/errorHandler.js';
 
 const allowedLinks = ['github.com', 'eddiejaoude.io', 'gitlab.com'];
-const urlPattern = /(http|https):\/\/([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?/g;
+const urlPattern =
+  /[Hh][Tt][Tt][Pp][Ss]?:\/\/([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?/g;
 
 export const checkLinks = async (
   bot: ExtendedClient,


### PR DESCRIPTION
## Changes proposed
It is possible currently to hide a link by capitalizing a letter in the http protocol.
This PR changes the regex to check for either case

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

